### PR TITLE
Add frase_en_alt field for progressive decontextualization

### DIFF
--- a/flashcards.py
+++ b/flashcards.py
@@ -38,7 +38,7 @@ C_BLUE = "\033[34m"
 C_CYAN = "\033[36m"
 C_MAGENTA = "\033[35m"
 
-CSV_HEADER = "id;tipo;palabra_en;palabra_es;frase_en;frase_en_cloze;frase_es;pronunciacion_ipa;registro;colocaciones;acepciones;por_que_ahora;fuente"
+CSV_HEADER = "id;tipo;palabra_en;palabra_es;frase_en;frase_en_cloze;frase_en_alt;frase_es;pronunciacion_ipa;registro;colocaciones;acepciones;por_que_ahora;fuente"
 
 ACCENT_TLD = {
     "us": "com",
@@ -112,11 +112,24 @@ def cmd_import(args):
         card_id = row[0].strip()
         tipo = row[1].strip().upper()
         palabra_en = row[2].strip()
-        # Support 11-col (legacy), 12-col (palabra_es), 13-col (+ frase_en_cloze)
-        if len(row) >= 13:
+        # Support 11-col (legacy), 12-col (palabra_es), 13-col (+ frase_en_cloze), 14-col (+ frase_en_alt)
+        if len(row) >= 14:
             palabra_es = row[3].strip()
             frase_en = row[4].strip()
             frase_en_cloze = row[5].strip()
+            frase_en_alt = row[6].strip()
+            frase_es = row[7].strip()
+            pronunciacion_ipa = row[8].strip()
+            registro = row[9].strip()
+            colocaciones = _parse_pipe_list(row[10])
+            acepciones = _parse_pipe_list(row[11])
+            por_que_ahora = row[12].strip()
+            fuente = row[13].strip()
+        elif len(row) >= 13:
+            palabra_es = row[3].strip()
+            frase_en = row[4].strip()
+            frase_en_cloze = row[5].strip()
+            frase_en_alt = ""
             frase_es = row[6].strip()
             pronunciacion_ipa = row[7].strip()
             registro = row[8].strip()
@@ -127,6 +140,7 @@ def cmd_import(args):
         elif len(row) >= 12:
             palabra_es = row[3].strip()
             frase_en_cloze = ""
+            frase_en_alt = ""
             frase_en = row[4].strip()
             frase_es = row[5].strip()
             pronunciacion_ipa = row[6].strip()
@@ -138,6 +152,7 @@ def cmd_import(args):
         else:
             palabra_es = ""
             frase_en_cloze = ""
+            frase_en_alt = ""
             frase_en = row[3].strip()
             frase_es = row[4].strip()
             pronunciacion_ipa = row[5].strip()
@@ -161,6 +176,7 @@ def cmd_import(args):
             "palabra_es": palabra_es,
             "frase_en": frase_en,
             "frase_en_cloze": frase_en_cloze,
+            "frase_en_alt": frase_en_alt,
             "frase_es": frase_es,
             "pronunciacion_ipa": pronunciacion_ipa,
             "registro": registro,
@@ -299,6 +315,9 @@ def _render_back(card, deck_name, reviewed, total, w):
         frase_en = card.get("frase_en", "")
         if frase_en:
             print(f"  {C_GREEN}\"{frase_en}\"{C_RESET}")
+        frase_en_alt = card.get("frase_en_alt", "")
+        if frase_en_alt:
+            print(f"  {C_DIM}\"{frase_en_alt}\"{C_RESET}")
         print(sep)
         if registro:
             print(f"  {C_DIM}Registro:{C_RESET} {registro}")
@@ -312,6 +331,9 @@ def _render_back(card, deck_name, reviewed, total, w):
         frase_en = card.get("frase_en", "")
         if frase_en:
             print(f"  {C_DIM}\"{frase_en}\"{C_RESET}")
+        frase_en_alt = card.get("frase_en_alt", "")
+        if frase_en_alt:
+            print(f"  {C_DIM}\"{frase_en_alt}\"{C_RESET}")
         print(sep)
         # Spanish translation + IPA
         answer_line = f"  {C_BOLD}{C_GREEN}{card.get('frase_es', '')}{C_RESET}"

--- a/prompt.txt
+++ b/prompt.txt
@@ -12,7 +12,7 @@ Te voy a pasar la transcripción de un video (serie, YouTube, TED Talk, podcast,
 ## Formato CSV
 
 Separador: `;` (punto y coma)
-Columnas: `id;tipo;palabra_en;palabra_es;frase_en;frase_en_cloze;frase_es;pronunciacion_ipa;registro;colocaciones;acepciones;por_que_ahora;fuente`
+Columnas: `id;tipo;palabra_en;palabra_es;frase_en;frase_en_cloze;frase_en_alt;frase_es;pronunciacion_ipa;registro;colocaciones;acepciones;por_que_ahora;fuente`
 
 ### Descripción de columnas
 
@@ -22,6 +22,7 @@ Columnas: `id;tipo;palabra_en;palabra_es;frase_en;frase_en_cloze;frase_es;pronun
 - **palabra_es**: La palabra o expresión en español tal como aparece en `frase_es` (para poder resaltarla). Debe ser una subcadena exacta de `frase_es`.
 - **frase_en**: Frase textual o casi textual de la transcripción donde aparece
 - **frase_en_cloze**: La misma frase pero con `palabra_en` reemplazada por `____`. Usa la forma conjugada exacta que aparece en `frase_en`. Ej: "I've never ____ a promise" (no "to renege on"). Si la expresión es muy corta y el cloze sería trivial (como "Hang on." → "____"), usa igualmente `____` para consistencia.
+- **frase_en_alt**: Segunda frase de ejemplo en un contexto diferente al de `frase_en`. Ayuda a la descontextualización progresiva. Puede ser inventada o de otra fuente. Dejar vacío si no hay ejemplo natural.
 - **frase_es**: Traducción natural de la frase al español
 - **pronunciacion_ipa**: Pronunciación IPA de `palabra_en`
 - **registro**: `formal`, `neutro`, `coloquial` o `vulgar`
@@ -33,10 +34,10 @@ Columnas: `id;tipo;palabra_en;palabra_es;frase_en;frase_en_cloze;frase_es;pronun
 ### Ejemplo
 
 ```
-001;A;to hang on;Espera;Hang on.;____.;Espera un momento.;/hæŋ ɒn/;coloquial;hang on a second|hang on tight|hang on a minute;esperar|agarrarse fuerte;;TBBT S01E01
-001;B;to hang on;Espera;Hang on.;____.;Espera un momento.;/hæŋ ɒn/;coloquial;hang on a second|hang on tight|hang on a minute;esperar|agarrarse fuerte;Phrasal verb muy frecuente en conversación oral, reemplaza a "wait";TBBT S01E01
-002;A;to wind up;Termina;She winds up a waitress at the Cheesecake Factory.;She ____ a waitress at the Cheesecake Factory.;Termina siendo camarera en el Cheesecake Factory.;/waɪnd ʌp/;coloquial;wind up in jail|wind up doing something|wind up broke;terminar siendo|acabar|resultar;;TBBT S01E01
-002;B;to wind up;Termina;She winds up a waitress at the Cheesecake Factory.;She ____ a waitress at the Cheesecake Factory.;Termina siendo camarera en el Cheesecake Factory.;/waɪnd ʌp/;coloquial;wind up in jail|wind up doing something|wind up broke;terminar siendo|acabar|resultar;Phrasal verb muy común para indicar resultado final o situación inesperada;TBBT S01E01
+001;A;to hang on;Espera;Hang on.;____.;Hang on, I'll be right back.;Espera un momento.;/hæŋ ɒn/;coloquial;hang on a second|hang on tight|hang on a minute;esperar|agarrarse fuerte;;TBBT S01E01
+001;B;to hang on;Espera;Hang on.;____.;Hang on, I'll be right back.;Espera un momento.;/hæŋ ɒn/;coloquial;hang on a second|hang on tight|hang on a minute;esperar|agarrarse fuerte;Phrasal verb muy frecuente en conversación oral, reemplaza a "wait";TBBT S01E01
+002;A;to wind up;Termina;She winds up a waitress at the Cheesecake Factory.;She ____ a waitress at the Cheesecake Factory.;He wound up sleeping on the couch.;Termina siendo camarera en el Cheesecake Factory.;/waɪnd ʌp/;coloquial;wind up in jail|wind up doing something|wind up broke;terminar siendo|acabar|resultar;;TBBT S01E01
+002;B;to wind up;Termina;She winds up a waitress at the Cheesecake Factory.;She ____ a waitress at the Cheesecake Factory.;He wound up sleeping on the couch.;Termina siendo camarera en el Cheesecake Factory.;/waɪnd ʌp/;coloquial;wind up in jail|wind up doing something|wind up broke;terminar siendo|acabar|resultar;Phrasal verb muy común para indicar resultado final o situación inesperada;TBBT S01E01
 ```
 
 ## Notas
@@ -44,6 +45,7 @@ Columnas: `id;tipo;palabra_en;palabra_es;frase_en;frase_en_cloze;frase_es;pronun
 - No incluyas header en el CSV (la primera fila ya es datos).
 - Las colocaciones y acepciones van separadas por `|` (pipe), NO por `;`.
 - `por_que_ahora` solo se llena en filas tipo B. En filas tipo A déjalo vacío.
+- `frase_en_alt` debe usar la palabra en un contexto diferente al de `frase_en` para favorecer la generalización. Si no hay un ejemplo natural, déjalo vacío.
 - `palabra_es` debe ser exactamente como aparece en `frase_es` (mismo tiempo verbal, misma forma) para que pueda resaltarse automáticamente.
 - Usa IPA americano.
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `frase_en_alt` column: a second example sentence in a different context to support progressive decontextualization
- Updates `CSV_HEADER` and import parser with full backwards compatibility (11, 12, 13 and new 14-column formats)
- Shows `frase_en_alt` on the back of cards (both tipo A and tipo B) when present
- Updates `prompt.txt` with column description, usage note, and updated examples

Closes #2
EOF
)